### PR TITLE
Added new components from PackageInfo.g template

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -41,6 +41,12 @@ AbstractHTML := "The <span class=\"pkgname\">IMG</span> package allows \
    GAP to manipulate iterated monodromy groups",
 PackageWWWHome := "http://laurentbartholdi.github.com/img/",
 
+SourceRepository := rec( 
+  Type := "git", 
+  URL := "https://github.com/laurentbartholdi/img"
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+
 PackageDoc := rec(
   BookName  := "IMG",
   HTMLStart := "doc/chap0.html",


### PR DESCRIPTION
This PR adds new optional components from the PackageInfo.g template
(https://github.com/gap-packages/example/blob/master/PackageInfo.g):
- Type and the URL of the source code repository
- URL of the public issue tracker
