### PR TITLE
Use SET_TYPE_DATOBJ

### DIFF
--- a/src/p1.c
+++ b/src/p1.c
@@ -31,7 +31,7 @@ Obj TYPE_P1POINT, TYPE_P1MAP, IsP1Point, IsP1Map,
 static Obj NEW_DATOBJ (size_t size, Obj type)
 {
   Obj obj = NewBag(T_DATOBJ,sizeof(Obj)+size);
-  TYPE_DATOBJ(obj) = type;
+  SET_TYPE_DATOBJ(obj, type);
   return obj;
 }
   


### PR DESCRIPTION
All released versions of GAP, up to and including GAP 4.9, have
SET_TYPE_DATOBJ. It only was temporarily gone in the GAP development
version, but it's been restored ages ago, and won't go anywhere.