### PR TITLE
Update configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 
 # autoconf
 AC_PREREQ([2.68])
-AC_INIT([img],[package],[https://github.com/gap-packages/img/issues],[io],[https://gap-packages.github.io/img])
+AC_INIT([img],[package],[https://github.com/gap-packages/img/issues],[img],[https://gap-packages.github.io/img])
 AC_CONFIG_SRCDIR([src/img.c])
 AC_CONFIG_AUX_DIR([cnf])
 AC_CONFIG_HEADERS([src/pkgconfig.h:cnf/pkgconfig.h.in])
@@ -38,7 +38,6 @@ AM_CONDITIONAL([SYS_IS_CYGWIN], [test "$CYGWIN" = "yes"])
 # gap
 FIND_GAP
 
-AC_CHECK_HEADERS_ONCE([float.h stdlib.h malloc/malloc.h malloc.h])
 AC_CHECK_LIB(m,sincos,AC_DEFINE(HAVE_SINCOS,1,do we have sincos?))
 
 # AC_CHECK_LEVMAR

--- a/m4/ax_cc_maxopt.m4
+++ b/m4/ax_cc_maxopt.m4
@@ -67,7 +67,7 @@ AC_REQUIRE([AC_PROG_CC])
 AC_REQUIRE([AX_COMPILER_VENDOR])
 AC_REQUIRE([AC_CANONICAL_HOST])
 
-AC_ARG_ENABLE(portable-binary, [AC_HELP_STRING([--enable-portable-binary], [disable compiler optimizations that would produce unportable binaries])],
+AC_ARG_ENABLE(portable-binary, [AS_HELP_STRING([--enable-portable-binary], [disable compiler optimizations that would produce unportable binaries])],
 	acx_maxopt_portable=$withval, acx_maxopt_portable=no)
 
 # Try to determine "good" native compiler flags if none specified via CFLAGS


### PR DESCRIPTION
- fix tarball name in AC_INIT (`io` -> `img`) -- not that we use it...
- replace the long-obsolete AC_HELP_STRING by AS_HELP_STRING
- remove checks for various header files: the results of the checks were not
  used anywhere; plus checking for float.h or stdlib.h is superfluous these
  days anyway