### PR TITLE
Use official, documented names of GAP functions, not internal ones

### DIFF
--- a/gap/complex.gi
+++ b/gap/complex.gi
@@ -86,11 +86,11 @@ end);
 
 InstallOtherMethod(IsZero, [IsPMComplex], x->IsZero(x![1]) and IsZero(x![2]));
 InstallOtherMethod(IsOne, [IsPMComplex], x->IsOne(x![1]) and IsZero(x![2]));
-InstallMethod(EQ, IsIdenticalObj, [IsPMComplex, IsPMComplex],
+InstallMethod(\=, IsIdenticalObj, [IsPMComplex, IsPMComplex],
         function(x,y)
     return x![1]=y![1] and x![2]=y![2];
 end);
-InstallMethod(LT, "for complex numbers",
+InstallMethod(\<, "for complex numbers",
         [IsPMComplex,IsPMComplex],
         function(x,y)
     return x![1]<y![1] or (x![1]=y![1] and x![2]<y![2]);
@@ -105,19 +105,19 @@ InstallMethod(Norm, [IsPMComplex], x->x![1]^2+x![2]^2);
 InstallMethod(AbsoluteValue, [IsPMComplex], x->Sqrt(x![1]^2+x![2]^2));
 InstallOtherMethod(Argument, [IsPMComplex], x->ATAN2_MACFLOAT(x![2],x![1]));
 
-InstallMethod(SUM, IsIdenticalObj, [IsPMComplex, IsPMComplex],
+InstallMethod(\+, IsIdenticalObj, [IsPMComplex, IsPMComplex],
         function(x,y)
     return Objectify(TYPE_PMCOMPLEX, [x![1]+y![1], x![2]+y![2]]);
 end);
 
-InstallMethod(DIFF, IsIdenticalObj, [IsPMComplex, IsPMComplex],
+InstallMethod(\-, IsIdenticalObj, [IsPMComplex, IsPMComplex],
         function(x,y)
     return Objectify(TYPE_PMCOMPLEX, [x![1]-y![1], x![2]-y![2]]);
 end);
 
-InstallMethod(AINV_MUT, [IsPMComplex], x->Objectify(TYPE_PMCOMPLEX, [-x![1],-x![2]]));
+InstallMethod(AdditiveInverseMutable, [IsPMComplex], x->Objectify(TYPE_PMCOMPLEX, [-x![1],-x![2]]));
 
-InstallOtherMethod(PROD, IsIdenticalObj, [IsPMComplex, IsPMComplex],
+InstallOtherMethod(\*, IsIdenticalObj, [IsPMComplex, IsPMComplex],
         function(x,y)
     return Objectify(TYPE_PMCOMPLEX, [x![1]*y![1]-x![2]*y![2],x![1]*y![2]+x![2]*y![1]]);
 end);
@@ -131,7 +131,7 @@ InstallOtherMethod(INV, [IsPMComplex], function(x)
     return Objectify(TYPE_PMCOMPLEX, [x![1]/r,-x![2]/r]);
 end);
 
-InstallOtherMethod(QUO, IsIdenticalObj, [IsPMComplex, IsPMComplex],
+InstallOtherMethod(\/, IsIdenticalObj, [IsPMComplex, IsPMComplex],
         function(x,y)
     if y=0.0_z then
         return PMCOMPLEX.constants.INFINITY;
@@ -139,7 +139,7 @@ InstallOtherMethod(QUO, IsIdenticalObj, [IsPMComplex, IsPMComplex],
     return x*INV(y);
 end);
 
-InstallOtherMethod(POW, IsIdenticalObj, [IsPMComplex, IsPMComplex],
+InstallOtherMethod(\^, IsIdenticalObj, [IsPMComplex, IsPMComplex],
         function(x,y)
     local r, n, a;
     a := ATAN2_MACFLOAT(x![2],x![1]);
@@ -149,7 +149,7 @@ InstallOtherMethod(POW, IsIdenticalObj, [IsPMComplex, IsPMComplex],
     return Objectify(TYPE_PMCOMPLEX, [r*COS_MACFLOAT(a),r*SIN_MACFLOAT(a)]);
 end);
 
-InstallOtherMethod(POW, [IsPMComplex, IsScalar],
+InstallOtherMethod(\^, [IsPMComplex, IsScalar],
         function(x,y)
     local r, a;
     r := (x![1]^2+x![2]^2)^Float(y/2);
@@ -157,7 +157,7 @@ InstallOtherMethod(POW, [IsPMComplex, IsScalar],
     return Objectify(TYPE_PMCOMPLEX, [r*COS_MACFLOAT(a),r*SIN_MACFLOAT(a)]);
 end);
 
-InstallOtherMethod(POW, [IsPMComplex, IsInt],
+InstallOtherMethod(\^, [IsPMComplex, IsInt],
         function(x,n)
     local j, xpow, y;
     if n=0 then return NewFloat(IsPMComplex,1); elif n<0 then n := -n; x := INV(x); fi;

--- a/gap/p1_ieee754.gi
+++ b/gap/p1_ieee754.gi
@@ -297,13 +297,13 @@ InstallMethod(DenominatorP1Map, "(IMG) for a P1 map", [IsIEEE754P1Map], P1MAPDEN
 InstallMethod(One, [IsIEEE754P1Map], f->P1MapByCoefficients([1.0_z],[1.0_z]));
 InstallMethod(Zero, [IsIEEE754P1Map], f->P1MapByCoefficients([0.0_z],[1.0_z]));
         
-InstallMethod(SUM, IsIdenticalObj, [IsIEEE754P1Map,IsIEEE754P1Map], P1MAP_SUM);
-InstallMethod(DIFF, IsIdenticalObj, [IsIEEE754P1Map,IsIEEE754P1Map], P1MAP_DIFF);
-InstallMethod(PROD, IsIdenticalObj, [IsIEEE754P1Map,IsIEEE754P1Map], P1MAP_PROD);
-InstallMethod(QUO, IsIdenticalObj, [IsIEEE754P1Map,IsIEEE754P1Map], P1MAP_QUO);
-InstallMethod(INV, [IsIEEE754P1Map], P1MAP_INV);
-InstallMethod(AINV, [IsIEEE754P1Map], P1MAP_AINV);
-Apply([SUM,DIFF,PROD,QUO],function(op)
+InstallMethod(\-, IsIdenticalObj, [IsIEEE754P1Map,IsIEEE754P1Map], P1MAP_SUM);
+InstallMethod(\-, IsIdenticalObj, [IsIEEE754P1Map,IsIEEE754P1Map], P1MAP_DIFF);
+InstallMethod(\*, IsIdenticalObj, [IsIEEE754P1Map,IsIEEE754P1Map], P1MAP_PROD);
+InstallMethod(\/, IsIdenticalObj, [IsIEEE754P1Map,IsIEEE754P1Map], P1MAP_QUO);
+InstallMethod(InverseMutable, [IsIEEE754P1Map], P1MAP_INV);
+InstallMethod(AdditiveInverseSameMutability, [IsIEEE754P1Map], P1MAP_AINV);
+Apply([\+,\-,\*,\/],function(op)
     local make;
     make := function(x)
         if IsRat(x) and not IsInt(x) then

--- a/gap/sphere.gd
+++ b/gap/sphere.gd
@@ -39,7 +39,7 @@ DeclareSynonym("IsMulticurve", IsSphereConjugacyClassCollection);
 DeclareOperation("InverseMutable", [IsSphereConjugacyClass]);
 DeclareOperation("InverseSameMutability", [IsSphereConjugacyClass]);
 DeclareAttribute("InverseImmutable", IsSphereConjugacyClass);
-DeclareOperation("POW", [IsSphereConjugacyClass,IsInt]);
+DeclareOperation("^", [IsSphereConjugacyClass,IsInt]);
 
 DeclareProperty("IsPeripheral", IsElementOfSphereGroup);
 DeclareProperty("IsPeripheral", IsSphereConjugacyClass);


### PR DESCRIPTION
This complements PR #27, but is less urgent, as unlike there, the internal names are not currently scheduled to change